### PR TITLE
Fix wrong username/password response

### DIFF
--- a/kmutnbtrackapp/templates/Page/log_in.html
+++ b/kmutnbtrackapp/templates/Page/log_in.html
@@ -35,6 +35,11 @@
                         <h1>Login</h1>
                     </div>
                 </div>
+                {% if wrong %}
+                <div class="col-md-12 text-center">
+                        <p style="color:red">Username หรือ Password ผิด กรุณาลองใหม่อีกครั้ง</p>
+                </div>
+                {% endif %}
                 <form action="{% url 'kmutnbtrackapp:login' %}?next={{ lab_hash }}" method="post" name="login">
                     {% csrf_token %}
                     <input value="{{lab_hash}}" name="next" hidden>

--- a/kmutnbtrackapp/views.py
+++ b/kmutnbtrackapp/views.py
@@ -174,17 +174,18 @@ def signup_api(request):  # when stranger click 'Signup and Checkin'
 
 
 def login_api(request):  # api when stranger login
-    print("Here")
     if request.method == "GET":
         lab_hash = request.GET.get('next', '')
         lab_name = ''
-        print(lab_hash)
         if lab_hash != '':
             lab_name = Lab.objects.get(hash=lab_hash).name
         return render(request, 'Page/log_in.html', {'lab_hash': lab_hash, 'lab_name': lab_name})
 
     if request.method == "POST":
-        lab_hash = request.POST.get('next', '')
+        lab_hash = request.GET.get('next', '')
+        lab_name = ''
+        if lab_hash != '':
+            lab_name = Lab.objects.get(hash=lab_hash).name
         username = request.POST['username']
         password = request.POST['password']
         user = authenticate(request, username=username, password=password)  # auth username and password
@@ -192,7 +193,7 @@ def login_api(request):  # api when stranger login
             login(request, user, backend='django.contrib.auth.backends.ModelBackend')
             return HttpResponseRedirect(reverse('kmutnbtrackapp:lab_home', args=(lab_hash,)))
         else:
-            return JsonResponse({"status": "fail"})
+            return render(request, 'Page/log_in.html', {'lab_hash': lab_hash, 'lab_name': lab_name, 'wrong': 1})
     # didn't receive POST
 
 


### PR DESCRIPTION
แก้เมื่อ user กรอก username หรือ password ผิด จากโชว์ {"status": "fail"} เป็น template ที่แจ้งผู้ใช้ว่าใส่ username หรือ password ผิด